### PR TITLE
Update dependencies and refactor Hub75 task

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -30,7 +30,6 @@ jobs:
           default: true
           buildtargets: esp32s3
           ldproxy: false
-          version: "1.85.0"
       - name: Enable caching
         uses: Swatinem/rust-cache@v2
       - name: Run build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,9 @@ name = "embassy-futures"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f878075b9794c1e4ac788c95b728f26aa6366d32eeb10c7051389f898f7d067"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "embassy-net"
@@ -1384,6 +1387,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "embassy-executor",
+ "embassy-futures",
  "embassy-net",
  "embassy-sync 0.7.0",
  "embassy-time",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.97"
+name = "allocator-api2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "78200ac3468a57d333cd0ea5dd398e25111194dcacd49208afca95c629a6311d"
+
+[[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "autocfg"
@@ -46,18 +52,18 @@ checksum = "f798d2d157e547aa99aab0967df39edd0b70307312b6f8bd2848e6abe40896e0"
 
 [[package]]
 name = "bitfield"
-version = "0.18.1"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7e6caee68becd795bfd65f1a026e4d00d8f0c2bc9be5eb568e1015f9ce3c34"
+checksum = "db1bcd90f88eabbf0cadbfb87a45bceeaebcd3b4bc9e43da379cd2ef0162590d"
 dependencies = [
  "bitfield-macros",
 ]
 
 [[package]]
 name = "bitfield-macros"
-version = "0.18.1"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331afbb18ce7b644c0b428726d369c5dd37ca0b815d72a459fcc2896c3c8ad32"
+checksum = "3787a07661997bfc05dd3431e379c0188573f78857080cf682e1393ab8e4d64c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -72,15 +78,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bytemuck"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 
 [[package]]
 name = "byteorder"
@@ -96,9 +102,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "num-traits",
 ]
@@ -129,6 +135,16 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "darling"
@@ -177,6 +193,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "crypto-common",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,7 +217,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fea5ef5bed4d3468dfd44f5c9fa4cda8f54c86d4fb4ae683eacf9d39e2ea12"
 dependencies = [
  "embassy-futures",
- "embassy-sync",
+ "embassy-sync 0.6.2",
  "embassy-time",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0",
@@ -233,13 +258,13 @@ checksum = "1f878075b9794c1e4ac788c95b728f26aa6366d32eeb10c7051389f898f7d067"
 
 [[package]]
 name = "embassy-net"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed041cc19a603d657124fddefdcbe5ef8bd60e77d972793ebb57de93394f5949"
+checksum = "940c4b9fe5c1375b09a0c6722c0100d6b2ed46a717a34f632f26e8d7327c4383"
 dependencies = [
  "document-features",
  "embassy-net-driver",
- "embassy-sync",
+ "embassy-sync 0.6.2",
  "embassy-time",
  "embedded-io-async",
  "embedded-nal-async",
@@ -259,6 +284,20 @@ name = "embassy-sync"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d2c8cdff05a7a51ba0087489ea44b0b1d97a296ca6b1d6d1a33ea7423d34049"
+dependencies = [
+ "cfg-if",
+ "critical-section",
+ "embedded-io-async",
+ "futures-sink",
+ "futures-util",
+ "heapless",
+]
+
+[[package]]
+name = "embassy-sync"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef1a8a1ea892f9b656de0295532ac5d8067e9830d49ec75076291fd6066b136"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -316,7 +355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08e753b23799329780c7ac434264026d0422044d6649ed70a73441b14a6436d7"
 dependencies = [
  "critical-section",
- "embassy-sync",
+ "embassy-sync 0.6.2",
  "embassy-usb-driver",
 ]
 
@@ -440,19 +479,18 @@ dependencies = [
 
 [[package]]
 name = "enumset"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a4b049558765cef5f0c1a273c3fc57084d768b44d2f98127aef4cceb17293"
+checksum = "11a6b7c3d347de0a9f7bfd2f853be43fe32fa6fac30c70f6d6d67a1e936b87ee"
 dependencies = [
  "enumset_derive",
- "serde",
 ]
 
 [[package]]
 name = "enumset_derive"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c3b24c345d8c314966bdc1832f6c2635bfcce8e7cf363bd115987bba2ee242"
+checksum = "6da3ea9e1d1a3b1593e15781f930120e72aa7501610b2f82e5b6739c72e8eac5"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -468,10 +506,11 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "esp-alloc"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78132d362cbf62ce22a1466eb9e98424f6b2d1e476e7a3cb46ca9063c5833f7"
+checksum = "7e95f1de57ce5a6600368f3d3c931b0dfe00501661e96f5ab83bc5cdee031784"
 dependencies = [
+ "allocator-api2",
  "cfg-if",
  "critical-section",
  "document-features",
@@ -481,20 +520,24 @@ dependencies = [
 
 [[package]]
 name = "esp-backtrace"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4cd70abe47945c9116972781b5c05277ad855a5f5569fe2afd3e2e61a103cc0"
+checksum = "7c304bbe17df32db8bc0027a9da989aa3efebbd4e7a79d58850deb29e2af577f"
 dependencies = [
+ "cfg-if",
  "esp-build",
+ "esp-config",
+ "esp-metadata",
  "esp-println",
+ "heapless",
  "semihosting",
 ]
 
 [[package]]
 name = "esp-build"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aa1c8f9954c9506699cf1ca10a2adcc226ff10b6ae3cb9e875cf2c6a0b9a372"
+checksum = "837020ff95fbf4c15c206541dda7994f1bbe6e1505e36a6a5ecb51fdb61656d7"
 dependencies = [
  "quote",
  "syn",
@@ -503,31 +546,33 @@ dependencies = [
 
 [[package]]
 name = "esp-config"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158dba334d3a2acd8d93873c0ae723ca1037cc78eefe5d6b4c5919b0ca28e38e"
+checksum = "2c8c4c95d8d6243ddb39efe1fcf2524c9becd0f86bb3e24048ed30b4f553609f"
 dependencies = [
  "document-features",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "esp-hal"
-version = "1.0.0-beta.0"
+version = "1.0.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9efaa9c1324ca20a22086aba2ce47a9bdc5bd65969af8b0cd5e879603b57bef"
+checksum = "0d973697621cd3eef9c3f260fa8c1af77d8547cfc92734255d8e8ddf05c7d331"
 dependencies = [
  "basic-toml",
- "bitfield 0.18.1",
- "bitflags 2.9.0",
+ "bitfield 0.19.1",
+ "bitflags 2.9.1",
  "bytemuck",
  "cfg-if",
- "chrono",
  "critical-section",
  "delegate",
+ "digest",
  "document-features",
  "embassy-embedded-hal",
  "embassy-futures",
- "embassy-sync",
+ "embassy-sync 0.6.2",
  "embassy-usb-driver",
  "embassy-usb-synopsys-otg",
  "embedded-can",
@@ -549,27 +594,27 @@ dependencies = [
  "nb 1.1.0",
  "paste",
  "portable-atomic",
- "rand_core",
+ "rand_core 0.6.4",
+ "rand_core 0.9.3",
  "riscv",
  "serde",
- "strum 0.27.1",
+ "strum",
  "ufmt-write",
- "usb-device",
- "void",
  "xtensa-lx",
  "xtensa-lx-rt",
 ]
 
 [[package]]
 name = "esp-hal-embassy"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b27f41110117a9bf2be385b42535c686b301c8ce3b5ea0a07567e200a63a2239"
+checksum = "7fd751f4b235764f6e766731e7da09d8f8d443642b829c3e6e469c38320da044"
 dependencies = [
+ "cfg-if",
  "critical-section",
  "document-features",
  "embassy-executor",
- "embassy-sync",
+ "embassy-sync 0.6.2",
  "embassy-time",
  "embassy-time-driver",
  "embassy-time-queue-utils",
@@ -584,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "esp-hal-procmacros"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd340a20a7d546570af58fd9e2aae17466a42572680d8e70d35fc7c475c4ed8"
+checksum = "73164008cb2eada2ef85e6b0e459001d851f9b8e65e96e0d594bdfa8cf1b813b"
 dependencies = [
  "darling",
  "document-features",
@@ -601,8 +646,9 @@ dependencies = [
 
 [[package]]
 name = "esp-hub75"
-version = "0.1.0"
-source = "git+https://github.com/liebman/esp-hub75.git?branch=main#889dc2590a7c66ee0eef3e56fb225a61366a88c8"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd4c1844d43d12c282f8afec2e011cfad8fb844d8064b837c1c5c163eab43ff4"
 dependencies = [
  "bitfield 0.17.0",
  "cfg-if",
@@ -618,33 +664,35 @@ dependencies = [
 
 [[package]]
 name = "esp-metadata"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b4bffc22b7b1222c9467f0cb90eb49dcb63de810ecb3300e4b3bbc4ac2423e"
+checksum = "0154d59933c2419ef25a01938517cc6969f47b6af53ebb34c279393aa20d9654"
 dependencies = [
  "anyhow",
  "basic-toml",
  "serde",
- "strum 0.26.3",
+ "strum",
 ]
 
 [[package]]
 name = "esp-println"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960703930f9f3c899ddedd122ea27a09d6a612c22323157e524af5b18876448e"
+checksum = "fae8b38d5fdc1d29d823c4737f18edfb0ccf0406985cf893f87c0cfc26a6ab33"
 dependencies = [
  "critical-section",
+ "document-features",
  "esp-build",
+ "esp-metadata",
  "log",
  "portable-atomic",
 ]
 
 [[package]]
 name = "esp-riscv-rt"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec69987b3d7c48b65f8fb829220832a101478d766c518ae836720d040608d5dd"
+checksum = "c05c2badd16cbd6307d463090615332b77c17a6766b41ba5fe5bb783310e8af6"
 dependencies = [
  "document-features",
  "riscv",
@@ -666,15 +714,15 @@ dependencies = [
 
 [[package]]
 name = "esp-wifi"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7d7ea0e2c374343a375758861e13cf618db619436bcb386dfe5529ef31e9d5"
+checksum = "4f0e7cc4d0ceed4117e0f190abba1f021d986a5b6a54ef2116541e4288b700a9"
 dependencies = [
+ "allocator-api2",
  "cfg-if",
  "critical-section",
  "document-features",
  "embassy-net-driver",
- "embassy-sync",
  "embedded-io",
  "embedded-io-async",
  "enumset",
@@ -684,15 +732,11 @@ dependencies = [
  "esp-hal",
  "esp-metadata",
  "esp-wifi-sys",
- "heapless",
- "libm",
- "log",
  "num-derive",
  "num-traits",
  "portable-atomic",
  "portable_atomic_enum",
- "rand_core",
- "serde",
+ "rand_core 0.9.3",
  "xtensa-lx-rt",
 ]
 
@@ -703,14 +747,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6b5438361891c431970194a733415006fb3d00b6eb70b3dcb66fd58f04d9b39"
 dependencies = [
  "anyhow",
- "log",
 ]
 
 [[package]]
 name = "esp32s3"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6d20f119410092abfbc65e46f9362015a7110023528f0dbe855cab80c38ca8"
+checksum = "27a4c6fd31207a297fc29d2b8f4da27facf45f8c83041f7c0f978aa65ab367c9"
 dependencies = [
  "critical-section",
  "vcell",
@@ -777,6 +820,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "heapless"
@@ -798,8 +851,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
  "hash32",
- "portable-atomic",
- "serde",
  "stable_deref_trait",
 ]
 
@@ -845,10 +896,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "libm"
-version = "0.2.11"
+name = "itoa"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "linked_list_allocator"
@@ -891,9 +942,9 @@ checksum = "c3c8dda44ff03a2f238717214da50f65d5a53b45cd213a7370424ffdb6fae815"
 
 [[package]]
 name = "minijinja"
-version = "2.9.0"
+version = "2.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98642a6dfca91122779a307b77cd07a4aa951fbe32232aaf5bad9febc66be754"
+checksum = "dd72e8b4e42274540edabec853f607c015c73436159b06c39c7af85a20433155"
 dependencies = [
  "serde",
 ]
@@ -1075,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -1109,7 +1160,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1117,6 +1168,12 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 
 [[package]]
 name = "regex"
@@ -1190,9 +1247,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
+name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "semihosting"
@@ -1218,6 +1281,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1282,33 +1357,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
- "strum_macros 0.27.1",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
+ "strum_macros",
 ]
 
 [[package]]
@@ -1332,7 +1385,7 @@ dependencies = [
  "chrono-tz",
  "embassy-executor",
  "embassy-net",
- "embassy-sync",
+ "embassy-sync 0.7.0",
  "embassy-time",
  "embedded-graphics",
  "embedded-hal 1.0.0",
@@ -1351,9 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1371,9 +1424,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1383,25 +1436,38 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
+
+[[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "ufmt-write"
@@ -1430,6 +1496,12 @@ name = "vcell"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "void"
@@ -1521,18 +1593,18 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.6"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "xtensa-lx"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51cbb46c78cfd284c9378070ab90bae9d14d38b3766cb853a97c0a137f736d5b"
+checksum = "68737a6c8f32ddcd97476acf68ddc6d411697fd94f64a601af16854b74967dff"
 dependencies = [
  "critical-section",
  "document-features",
@@ -1540,9 +1612,9 @@ dependencies = [
 
 [[package]]
 name = "xtensa-lx-rt"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "689c2ef159d9cd4fc9503603e9999968a84a30db9bde0f0f880d0cceea0190a9"
+checksum = "235815f34d1bf9c2f9c07917e2b63efbcab5ca5ce9d8faddb97b7105eed1ade3"
 dependencies = [
  "anyhow",
  "document-features",
@@ -1550,7 +1622,7 @@ dependencies = [
  "minijinja",
  "r0",
  "serde",
- "strum 0.26.3",
+ "strum",
  "toml",
  "xtensa-lx",
  "xtensa-lx-rt-proc-macros",
@@ -1558,9 +1630,9 @@ dependencies = [
 
 [[package]]
 name = "xtensa-lx-rt-proc-macros"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11277b1e4cbb7ffe44678c668518b249c843c81df249b8f096701757bc50d7ee"
+checksum = "6c1ab67b22f0576b953a25c43bdfed0ff84af2e01ced85e95c29e7bac6bf2180"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1397,6 +1397,7 @@ dependencies = [
  "esp-println",
  "esp-wifi",
  "heapless",
+ "log",
  "pcf8563",
  "sntpc",
  "static_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ sntpc = { version = "0.5.2", default-features = false, features = [
 chrono = { version = "0.4.41", default-features = false }
 chrono-tz = { version = "0.10.3", default-features = false }
 log = "0.4.27"
+embassy-futures = { version = "0.1.1", features = ["log"] }
 
 [profile.dev]
 # Rust debug is too slow.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,18 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+esp-println = { version = "0.14.0", features = ["esp32s3", "log-04"] }
 embassy-sync = { version = "0.7.0", features = [] }
 embassy-time = { version = "0.4.0", features = [] }
 static_cell = "2.1.0"
 embassy-executor = { version = "0.7.0", features = ["task-arena-size-12288"] }
 heapless = { version = "0.8.0", default-features = false }
-esp-println = { version = "0.14.0", features = ["esp32s3"] }
 esp-hal-embassy = { version = "0.8.0", features = ["esp32s3"] }
-esp-hal = { version = "1.0.0-beta.1", features = ["esp32s3", "unstable"] }
+esp-hal = { version = "1.0.0-beta.1", features = [
+    "esp32s3",
+    "unstable",
+    "log-04",
+] }
 esp-hub75 = { version = "0.2.0", features = ["esp32s3", "log"] }
 esp-wifi = { version = "0.14.0", features = ["esp32s3", "wifi"] }
 esp-alloc = { version = "0.8.0" }
@@ -37,6 +41,7 @@ sntpc = { version = "0.5.2", default-features = false, features = [
 ] }
 chrono = { version = "0.4.41", default-features = false }
 chrono-tz = { version = "0.10.3", default-features = false }
+log = "0.4.27"
 
 [profile.dev]
 # Rust debug is too slow.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,30 +4,18 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-embassy-sync = { version = "0.6.2", features = [] }
+embassy-sync = { version = "0.7.0", features = [] }
 embassy-time = { version = "0.4.0", features = [] }
 static_cell = "2.1.0"
 embassy-executor = { version = "0.7.0", features = ["task-arena-size-12288"] }
 heapless = { version = "0.8.0", default-features = false }
-esp-println = { version = "0.13.1", features = ["log", "esp32s3"] }
-esp-hal-embassy = { version = "0.7.0", features = ["esp32s3"] }
-esp-hal = { version = "1.0.0-beta.0", features = [
-    "esp32s3",
-    "unstable",
-    "log",
-] }
-esp-hub75 = { git = "https://github.com/liebman/esp-hub75.git", branch = "main", features = [
-    "esp32s3",
-    "log",
-] }
-esp-wifi = { version = "0.13.0", features = [
-    "esp32s3",
-    "serde",
-    "wifi",
-    "log",
-] }
-esp-alloc = { version = "0.7.0" }
-esp-backtrace = { version = "0.15.1", features = [
+esp-println = { version = "0.14.0", features = ["esp32s3"] }
+esp-hal-embassy = { version = "0.8.0", features = ["esp32s3"] }
+esp-hal = { version = "1.0.0-beta.1", features = ["esp32s3", "unstable"] }
+esp-hub75 = { version = "0.2.0", features = ["esp32s3", "log"] }
+esp-wifi = { version = "0.14.0", features = ["esp32s3", "wifi"] }
+esp-alloc = { version = "0.8.0" }
+esp-backtrace = { version = "0.16.0", features = [
     "esp32s3",
     "exception-handler",
     "panic-handler",
@@ -35,7 +23,7 @@ esp-backtrace = { version = "0.15.1", features = [
 ] }
 embedded-graphics = { version = "0.8.1", features = [] }
 embedded-hal = { version = "1.0.0", features = [] }
-embassy-net = { version = "0.6.0", features = [
+embassy-net = { version = "0.7.0", features = [
     "tcp",
     "udp",
     "dns",
@@ -47,7 +35,7 @@ sntpc = { version = "0.5.2", default-features = false, features = [
     "embassy-socket",
     "log",
 ] }
-chrono = { version = "0.4.40", default-features = false }
+chrono = { version = "0.4.41", default-features = false }
 chrono-tz = { version = "0.10.3", default-features = false }
 
 [profile.dev]

--- a/src/display/hub75_task.rs
+++ b/src/display/hub75_task.rs
@@ -2,8 +2,16 @@ use core::sync::atomic::Ordering;
 
 use embassy_executor::task;
 use embassy_time::{Duration, Instant};
-use esp_hal::{gpio::AnyPin, peripherals::LCD_CAM, system::Cpu, time::Rate};
-use esp_hub75::{lcd_cam::Hub75, Hub75Pins};
+use esp_hal::{
+    gpio::Pin,
+    peripherals::{
+        DMA_CH0, GPIO10, GPIO11, GPIO2, GPIO21, GPIO3, GPIO33, GPIO34, GPIO35, GPIO36, GPIO37,
+        GPIO38, GPIO39, GPIO6, GPIO7, LCD_CAM,
+    },
+    system::Cpu,
+    time::Rate,
+};
+use esp_hub75::{Hub75, Hub75Pins16};
 use esp_println::println;
 
 use crate::{FBType, FrameBufferExchange, REFRESH_RATE};
@@ -11,22 +19,22 @@ use crate::{FBType, FrameBufferExchange, REFRESH_RATE};
 type Hub75Type = Hub75<'static, esp_hal::Async>;
 
 pub(crate) struct Hub75Peripherals {
-    pub lcd_cam: LCD_CAM,
-    pub dma_channel: esp_hal::dma::DmaChannel0,
-    pub red1: AnyPin,
-    pub grn1: AnyPin,
-    pub blu1: AnyPin,
-    pub red2: AnyPin,
-    pub grn2: AnyPin,
-    pub blu2: AnyPin,
-    pub addr0: AnyPin,
-    pub addr1: AnyPin,
-    pub addr2: AnyPin,
-    pub addr3: AnyPin,
-    pub addr4: AnyPin,
-    pub blank: AnyPin,
-    pub clock: AnyPin,
-    pub latch: AnyPin,
+    pub lcd_cam: LCD_CAM<'static>,
+    pub dma_channel: DMA_CH0<'static>,
+    pub red1: GPIO2<'static>,
+    pub grn1: GPIO6<'static>,
+    pub blu1: GPIO10<'static>,
+    pub red2: GPIO3<'static>,
+    pub grn2: GPIO7<'static>,
+    pub blu2: GPIO11<'static>,
+    pub addr0: GPIO39<'static>,
+    pub addr1: GPIO38<'static>,
+    pub addr2: GPIO37<'static>,
+    pub addr3: GPIO36<'static>,
+    pub addr4: GPIO21<'static>,
+    pub blank: GPIO35<'static>,
+    pub clock: GPIO34<'static>,
+    pub latch: GPIO33<'static>,
 }
 
 #[task]
@@ -40,21 +48,21 @@ pub(crate) async fn hub75_task(
     let channel = peripherals.dma_channel;
     let (_, tx_descriptors) = esp_hal::dma_descriptors!(0, size_of::<FBType>());
 
-    let pins = Hub75Pins {
-        red1: peripherals.red1,
-        grn1: peripherals.grn1,
-        blu1: peripherals.blu1,
-        red2: peripherals.red2,
-        grn2: peripherals.grn2,
-        blu2: peripherals.blu2,
-        addr0: peripherals.addr0,
-        addr1: peripherals.addr1,
-        addr2: peripherals.addr2,
-        addr3: peripherals.addr3,
-        addr4: peripherals.addr4,
-        blank: peripherals.blank,
-        clock: peripherals.clock,
-        latch: peripherals.latch,
+    let pins = Hub75Pins16 {
+        red1: peripherals.red1.degrade(),
+        grn1: peripherals.grn1.degrade(),
+        blu1: peripherals.blu1.degrade(),
+        red2: peripherals.red2.degrade(),
+        grn2: peripherals.grn2.degrade(),
+        blu2: peripherals.blu2.degrade(),
+        addr0: peripherals.addr0.degrade(),
+        addr1: peripherals.addr1.degrade(),
+        addr2: peripherals.addr2.degrade(),
+        addr3: peripherals.addr3.degrade(),
+        addr4: peripherals.addr4.degrade(),
+        blank: peripherals.blank.degrade(),
+        clock: peripherals.clock.degrade(),
+        latch: peripherals.latch.degrade(),
     };
 
     let mut hub75 = Hub75Type::new_async(

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,6 @@ use embassy_time::{Duration, Timer};
 use esp_alloc::heap_allocator;
 use esp_backtrace as _;
 use esp_hal::{
-    gpio::Pin,
     i2c::master::{Config, I2c},
     interrupt::{software::SoftwareInterruptControl, Priority},
     system::{CpuControl, Stack},
@@ -22,8 +21,7 @@ use esp_hal::{
     Blocking,
 };
 use esp_hal_embassy::{main, InterruptExecutor};
-use esp_hub75::framebuffer::DmaFrameBuffer;
-use esp_hub75::framebuffer::{compute_frame_count, compute_rows};
+use esp_hub75::framebuffer::{compute_frame_count, compute_rows, latched::DmaFrameBuffer};
 use esp_println::println;
 use wifi_task::{connect_to_wifi, STOP_WIFI_SIGNAL};
 
@@ -100,20 +98,20 @@ async fn main(spawner: Spawner) {
     let hub75_peripherals = Hub75Peripherals {
         lcd_cam: peripherals.LCD_CAM,
         dma_channel: peripherals.DMA_CH0,
-        red1: peripherals.GPIO2.degrade(),
-        grn1: peripherals.GPIO6.degrade(),
-        blu1: peripherals.GPIO10.degrade(),
-        red2: peripherals.GPIO3.degrade(),
-        grn2: peripherals.GPIO7.degrade(),
-        blu2: peripherals.GPIO11.degrade(),
-        addr0: peripherals.GPIO39.degrade(),
-        addr1: peripherals.GPIO38.degrade(),
-        addr2: peripherals.GPIO37.degrade(),
-        addr3: peripherals.GPIO36.degrade(),
-        addr4: peripherals.GPIO21.degrade(),
-        blank: peripherals.GPIO35.degrade(),
-        clock: peripherals.GPIO34.degrade(),
-        latch: peripherals.GPIO33.degrade(),
+        red1: peripherals.GPIO2,
+        grn1: peripherals.GPIO6,
+        blu1: peripherals.GPIO10,
+        red2: peripherals.GPIO3,
+        grn2: peripherals.GPIO7,
+        blu2: peripherals.GPIO11,
+        addr0: peripherals.GPIO39,
+        addr1: peripherals.GPIO38,
+        addr2: peripherals.GPIO37,
+        addr3: peripherals.GPIO36,
+        addr4: peripherals.GPIO21,
+        blank: peripherals.GPIO35,
+        clock: peripherals.GPIO34,
+        latch: peripherals.GPIO33,
     };
 
     // run hub75 and display on second core

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ use esp_hal::{
 };
 use esp_hal_embassy::{main, InterruptExecutor};
 use esp_hub75::framebuffer::{compute_frame_count, compute_rows, plain::DmaFrameBuffer};
-use esp_println::println;
+use esp_println::{logger::init_logger, println};
 use wifi_task::{connect_to_wifi, STOP_WIFI_SIGNAL};
 
 mod clock;
@@ -62,6 +62,8 @@ pub(crate) trait ClockfaceTrait {
 
 #[main]
 async fn main(spawner: Spawner) {
+    init_logger(log::LevelFilter::Info);
+
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
     // --- RTC Initialization Start ---

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ use esp_hal::{
 use esp_hal_embassy::{main, InterruptExecutor};
 use esp_hub75::framebuffer::{compute_frame_count, compute_rows, plain::DmaFrameBuffer};
 use esp_println::{logger::init_logger, println};
-use wifi_task::{connect_to_wifi, STOP_WIFI_SIGNAL};
+use wifi_task::{connect_to_wifi, shutdown_wifi};
 
 mod clock;
 mod display;
@@ -171,9 +171,10 @@ async fn main(spawner: Spawner) {
     let time = Clock::<I2CType>::get_time_in_zone(chrono_tz::Europe::Zurich);
     println!("Current time: {}", time);
 
-    println!("Request to disconnect wifi");
+    println!("Shutting down WiFi and network stack");
 
-    STOP_WIFI_SIGNAL.signal(());
+    // Properly shutdown WiFi
+    shutdown_wifi().await;
 
     loop {
         // The main task keeps running so the executor doesn't exit

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use esp_hal::{
     Blocking,
 };
 use esp_hal_embassy::{main, InterruptExecutor};
-use esp_hub75::framebuffer::{compute_frame_count, compute_rows, latched::DmaFrameBuffer};
+use esp_hub75::framebuffer::{compute_frame_count, compute_rows, plain::DmaFrameBuffer};
 use esp_println::println;
 use wifi_task::{connect_to_wifi, STOP_WIFI_SIGNAL};
 

--- a/src/wifi_task.rs
+++ b/src/wifi_task.rs
@@ -21,10 +21,10 @@ static STACK_RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
 pub(crate) static STOP_WIFI_SIGNAL: Signal<CriticalSectionRawMutex, ()> = Signal::new();
 
 pub async fn connect_to_wifi(
-    wifi: peripherals::WIFI,
-    timer: esp_hal::timer::timg::Timer,
-    radio_clocks: peripherals::RADIO_CLK,
-    rng: RNG,
+    wifi: peripherals::WIFI<'static>,
+    timer: esp_hal::timer::timg::Timer<'static>,
+    radio_clocks: peripherals::RADIO_CLK<'static>,
+    rng: RNG<'static>,
     spawner: Spawner,
 ) -> Result<Stack<'static>, WifiError> {
     let mut rng = Rng::new(rng);

--- a/src/wifi_task.rs
+++ b/src/wifi_task.rs
@@ -20,6 +20,23 @@ static STACK_RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
 /// Signal to request to stop WiFi
 pub(crate) static STOP_WIFI_SIGNAL: Signal<CriticalSectionRawMutex, ()> = Signal::new();
 
+/// Signal to stop network task
+static STOP_NET_SIGNAL: Signal<CriticalSectionRawMutex, ()> = Signal::new();
+
+/// Shutdown WiFi and clean up resources
+pub async fn shutdown_wifi() {
+    println!("Requesting WiFi shutdown...");
+
+    // Signal both tasks to stop
+    STOP_WIFI_SIGNAL.signal(());
+    STOP_NET_SIGNAL.signal(());
+
+    // Wait longer for proper cleanup
+    Timer::after(Duration::from_millis(3000)).await;
+
+    println!("WiFi shutdown complete");
+}
+
 pub async fn connect_to_wifi(
     wifi: peripherals::WIFI<'static>,
     timer: esp_hal::timer::timg::Timer<'static>,
@@ -72,7 +89,18 @@ pub async fn connect_to_wifi(
 
 #[embassy_executor::task]
 async fn net_task(mut runner: Runner<'static, WifiDevice<'static>>) {
-    runner.run().await
+    use embassy_futures::select::{select, Either};
+
+    match select(runner.run(), STOP_NET_SIGNAL.wait()).await {
+        Either::First(_) => {
+            // Runner completed
+        }
+        Either::Second(_) => {
+            // Stop signal received
+            println!("Network task received stop signal");
+        }
+    }
+    println!("Network task stopped");
 }
 
 /// Task for WiFi connection
@@ -121,7 +149,14 @@ async fn connection_fallible(mut controller: WifiController<'static>) -> Result<
                 println!("Wait for request to stop wifi");
                 STOP_WIFI_SIGNAL.wait().await;
                 println!("Received signal to stop wifi");
-                controller.stop_async().await?;
+
+                // Proper shutdown sequence
+                if let Err(e) = controller.disconnect_async().await {
+                    println!("Error disconnecting: {:?}", e);
+                }
+                if let Err(e) = controller.stop_async().await {
+                    println!("Error stopping controller: {:?}", e);
+                }
                 break;
             }
             Err(error) => {


### PR DESCRIPTION
- Updated Rust dependencies in Cargo.lock and Cargo.toml to their latest versions, including esp-hal, esp-hub75, embassy-sync, and others.
- Refactored Hub75 task to use new GPIO types and updated the Hub75Pins structure to Hub75Pins16.
- Adjusted the main function to accommodate changes in the Hub75Peripherals structure.
- Updated the connect_to_wifi function to use static lifetimes for peripherals.
- Removed deprecated features and ensured compatibility with the latest embassy and esp-hal versions.